### PR TITLE
Fix typo in recipe/item/entity names

### DIFF
--- a/src/migrations/0.2-rewrite.json
+++ b/src/migrations/0.2-rewrite.json
@@ -1,28 +1,28 @@
 {
     "entity":
     [
-        ["aai-bobs-basic-loader", "aai-boblogistics-basic-loader"],
+        ["aai-bob-basic-loader", "aai-boblogistics-basic-loader"],
         ["aai-loader", "aai-boblogistics-loader"],
         ["aai-fast-loader", "aai-boblogistics-fast-loader"],
         ["aai-express-loader", "aai-boblogistics-express-loader"],
-        ["aai-bobs-turbo-loader", "aai-boblogistics-turbo-loader"],
-        ["aai-bobs-ultimate-loader", "aai-boblogistics-ultimate-loader"],
+        ["aai-bob-turbo-loader", "aai-boblogistics-turbo-loader"],
+        ["aai-bob-ultimate-loader", "aai-boblogistics-ultimate-loader"],
 
-        ["aai-bobs-basic-loader-pipe", "aai-boblogistics-basic-loader-pipe"],
+        ["aai-bob-basic-loader-pipe", "aai-boblogistics-basic-loader-pipe"],
         ["aai-loader-pipe", "aai-boblogistics-loader-pipe"],
         ["aai-fast-loader-pipe", "aai-boblogistics-fast-loader-pipe"],
         ["aai-express-loader-pipe", "aai-boblogistics-express-loader-pipe"],
-        ["aai-bobs-turbo-loader-pipe", "aai-boblogistics-turbo-loader-pipe"],
-        ["aai-bobs-ultimate-loader-pipe", "aai-boblogistics-ultimate-loader-pipe"]
+        ["aai-bob-turbo-loader-pipe", "aai-boblogistics-turbo-loader-pipe"],
+        ["aai-bob-ultimate-loader-pipe", "aai-boblogistics-ultimate-loader-pipe"]
     ],
     "item":
     [
-        ["aai-bobs-basic-loader", "aai-boblogistics-basic-loader"],
+        ["aai-bob-basic-loader", "aai-boblogistics-basic-loader"],
         ["aai-loader", "aai-boblogistics-loader"],
         ["aai-fast-loader", "aai-boblogistics-fast-loader"],
         ["aai-express-loader", "aai-boblogistics-express-loader"],
-        ["aai-bobs-turbo-loader", "aai-boblogistics-turbo-loader"],
-        ["aai-bobs-ultimate-loader", "aai-boblogistics-ultimate-loader"]
+        ["aai-bob-turbo-loader", "aai-boblogistics-turbo-loader"],
+        ["aai-bob-ultimate-loader", "aai-boblogistics-ultimate-loader"]
     ],
     "technology":
     [
@@ -35,11 +35,11 @@
     ],
     "recipe":
     [
-        ["aai-bobs-basic-loader", "aai-boblogistics-basic-loader"],
+        ["aai-bob-basic-loader", "aai-boblogistics-basic-loader"],
         ["aai-loader", "aai-boblogistics-loader"],
         ["aai-fast-loader", "aai-boblogistics-fast-loader"],
         ["aai-express-loader", "aai-boblogistics-express-loader"],
-        ["aai-bobs-turbo-loader", "aai-boblogistics-turbo-loader"],
-        ["aai-bobs-ultimate-loader", "aai-boblogistics-ultimate-loader"]
+        ["aai-bob-turbo-loader", "aai-boblogistics-turbo-loader"],
+        ["aai-bob-ultimate-loader", "aai-boblogistics-ultimate-loader"]
     ]
 }


### PR DESCRIPTION
The techs are called `aai-bobs-<whatever>`, but the entities/items/recipes are called `aai-bob-<whatever>` (no "s").

Fixes issue #7.